### PR TITLE
Fix function name mismatch

### DIFF
--- a/memcacheshim.class.php
+++ b/memcacheshim.class.php
@@ -154,7 +154,7 @@ class MemcacheShim
     public function connect($host, $port = 11211, $timeout = 0)
     {
         $this->addServer($host, $port);
-        return $this->is_connected($host, $port);
+        return $this->server_is_connected($host, $port);
     }
 
     /**


### PR DESCRIPTION
Fix for PHP Fatal error:  Uncaught Error: Call to undefined method MemcacheShim::is_connected()